### PR TITLE
feat(devenv): add Claude Code and Codex installation support

### DIFF
--- a/src/devenv/devcontainer-feature.json
+++ b/src/devenv/devcontainer-feature.json
@@ -33,6 +33,16 @@
             "type": "string",
             "description": "neovim version to install (e.g., '0.9.5', 'latest')",
             "default": "latest"
+        },
+        "installClaudeCode": {
+            "type": "boolean",
+            "description": "Install Claude Code CLI (AI coding assistant)",
+            "default": true
+        },
+        "installCodex": {
+            "type": "boolean",
+            "description": "Install OpenAI Codex CLI (requires npm)",
+            "default": true
         }
     }
 }

--- a/src/devenv/install.sh
+++ b/src/devenv/install.sh
@@ -9,6 +9,8 @@ set -e
 INSTALL_TMUX="${INSTALLTMUX:-true}"
 INSTALL_LAZYGIT="${INSTALLLAZYGIT:-true}"
 INSTALL_NVIM="${INSTALLNVIM:-true}"
+INSTALL_CLAUDE_CODE="${INSTALLCLAUDECODE:-true}"
+INSTALL_CODEX="${INSTALLCODEX:-true}"
 TMUX_VERSION="${TMUXVERSION:-latest}"
 LAZYGIT_VERSION="${LAZYGITVERSION:-latest}"
 NVIM_VERSION="${NVIMVERSION:-latest}"
@@ -369,6 +371,62 @@ install_fzf() {
     return 0
 }
 
+# Install Claude Code CLI
+install_claude_code() {
+    if [ "$INSTALL_CLAUDE_CODE" != "true" ]; then
+        echo "Skipping Claude Code installation (disabled)"
+        return 0
+    fi
+
+    echo "Installing Claude Code..."
+
+    # Check if claude is already installed
+    if command -v claude &>/dev/null; then
+        echo "Claude Code is already installed, skipping"
+        return 0
+    fi
+
+    # Install Claude Code using the official install script
+    if curl -fsSL https://claude.ai/install.sh | bash; then
+        echo "Claude Code installed successfully"
+    else
+        echo "WARNING: Failed to install Claude Code" >&2
+    fi
+
+    return 0
+}
+
+# Install OpenAI Codex CLI
+install_codex() {
+    if [ "$INSTALL_CODEX" != "true" ]; then
+        echo "Skipping Codex installation (disabled)"
+        return 0
+    fi
+
+    echo "Installing Codex..."
+
+    # Check if codex is already installed
+    if command -v codex &>/dev/null; then
+        echo "Codex is already installed, skipping"
+        return 0
+    fi
+
+    # Check if npm is available
+    if ! command -v npm &>/dev/null; then
+        echo "WARNING: npm is not installed, skipping Codex installation" >&2
+        return 0
+    fi
+
+    # Install Codex globally using npm
+    if npm i -g @openai/codex; then
+        echo "Codex installed successfully"
+    else
+        echo "WARNING: Failed to install Codex" >&2
+    fi
+
+    return 0
+}
+
 # Main installation
 main() {
     echo "Starting devenv feature installation..."
@@ -376,6 +434,8 @@ main() {
     echo "  INSTALL_TMUX=$INSTALL_TMUX"
     echo "  INSTALL_LAZYGIT=$INSTALL_LAZYGIT"
     echo "  INSTALL_NVIM=$INSTALL_NVIM"
+    echo "  INSTALL_CLAUDE_CODE=$INSTALL_CLAUDE_CODE"
+    echo "  INSTALL_CODEX=$INSTALL_CODEX"
     echo "  TMUX_VERSION=$TMUX_VERSION"
     echo "  LAZYGIT_VERSION=$LAZYGIT_VERSION"
     echo "  NVIM_VERSION=$NVIM_VERSION"
@@ -391,6 +451,8 @@ main() {
     install_tmux
     install_lazygit
     install_nvim
+    install_claude_code
+    install_codex
 
     echo "devenv feature installation complete"
 }

--- a/test/devenv/all-disabled.sh
+++ b/test/devenv/all-disabled.sh
@@ -52,4 +52,20 @@ else
     echo "PASS: fzf is not installed (as expected)"
 fi
 
+# Test Claude Code (should NOT be installed)
+if command -v claude &>/dev/null; then
+    echo "FAIL: claude should not be installed"
+    exit 1
+else
+    echo "PASS: claude is not installed (as expected)"
+fi
+
+# Test Codex (should NOT be installed)
+if command -v codex &>/dev/null; then
+    echo "FAIL: codex should not be installed"
+    exit 1
+else
+    echo "PASS: codex is not installed (as expected)"
+fi
+
 echo "All tests passed!"

--- a/test/devenv/claude-code-only.sh
+++ b/test/devenv/claude-code-only.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+# Test claude-code-only installation - only Claude Code should be installed
+echo "Testing claude-code-only installation..."
+
+# Test Claude Code (should be installed)
+if command -v claude &>/dev/null; then
+    echo "PASS: claude is installed"
+else
+    echo "FAIL: claude is not installed"
+    exit 1
+fi
+
+# Test tmux (should NOT be installed)
+if command -v tmux &>/dev/null; then
+    echo "FAIL: tmux should not be installed"
+    exit 1
+else
+    echo "PASS: tmux is not installed (as expected)"
+fi
+
+# Test lazygit (should NOT be installed)
+if command -v lazygit &>/dev/null; then
+    echo "FAIL: lazygit should not be installed"
+    exit 1
+else
+    echo "PASS: lazygit is not installed (as expected)"
+fi
+
+# Test neovim (should NOT be installed)
+if command -v nvim &>/dev/null; then
+    echo "FAIL: nvim should not be installed"
+    exit 1
+else
+    echo "PASS: nvim is not installed (as expected)"
+fi
+
+# Test codex (should NOT be installed)
+if command -v codex &>/dev/null; then
+    echo "FAIL: codex should not be installed"
+    exit 1
+else
+    echo "PASS: codex is not installed (as expected)"
+fi
+
+echo "All tests passed!"

--- a/test/devenv/codex-only.sh
+++ b/test/devenv/codex-only.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+# Test codex-only installation - only Codex should be installed
+echo "Testing codex-only installation..."
+
+# Test Codex (should be installed)
+if command -v codex &>/dev/null; then
+    echo "PASS: codex is installed"
+else
+    echo "FAIL: codex is not installed"
+    exit 1
+fi
+
+# Test tmux (should NOT be installed)
+if command -v tmux &>/dev/null; then
+    echo "FAIL: tmux should not be installed"
+    exit 1
+else
+    echo "PASS: tmux is not installed (as expected)"
+fi
+
+# Test lazygit (should NOT be installed)
+if command -v lazygit &>/dev/null; then
+    echo "FAIL: lazygit should not be installed"
+    exit 1
+else
+    echo "PASS: lazygit is not installed (as expected)"
+fi
+
+# Test neovim (should NOT be installed)
+if command -v nvim &>/dev/null; then
+    echo "FAIL: nvim should not be installed"
+    exit 1
+else
+    echo "PASS: nvim is not installed (as expected)"
+fi
+
+# Test Claude Code (should NOT be installed)
+if command -v claude &>/dev/null; then
+    echo "FAIL: claude should not be installed"
+    exit 1
+else
+    echo "PASS: claude is not installed (as expected)"
+fi
+
+echo "All tests passed!"

--- a/test/devenv/scenarios.json
+++ b/test/devenv/scenarios.json
@@ -2,7 +2,10 @@
     "default": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
-            "devenv": {}
+            "devenv": {
+                "installClaudeCode": false,
+                "installCodex": false
+            }
         }
     },
     "tmux-only": {
@@ -10,7 +13,9 @@
         "features": {
             "devenv": {
                 "installLazygit": false,
-                "installNvim": false
+                "installNvim": false,
+                "installClaudeCode": false,
+                "installCodex": false
             }
         }
     },
@@ -19,7 +24,9 @@
         "features": {
             "devenv": {
                 "installTmux": false,
-                "installNvim": false
+                "installNvim": false,
+                "installClaudeCode": false,
+                "installCodex": false
             }
         }
     },
@@ -28,7 +35,9 @@
         "features": {
             "devenv": {
                 "installTmux": false,
-                "installLazygit": false
+                "installLazygit": false,
+                "installClaudeCode": false,
+                "installCodex": false
             }
         }
     },
@@ -38,7 +47,9 @@
             "devenv": {
                 "installTmux": false,
                 "installLazygit": false,
-                "installNvim": false
+                "installNvim": false,
+                "installClaudeCode": false,
+                "installCodex": false
             }
         }
     },
@@ -48,7 +59,33 @@
             "devenv": {
                 "tmuxVersion": "3.4",
                 "lazygitVersion": "0.40.2",
-                "nvimVersion": "v0.10.4"
+                "nvimVersion": "v0.10.4",
+                "installClaudeCode": false,
+                "installCodex": false
+            }
+        }
+    },
+    "claude-code-only": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "devenv": {
+                "installTmux": false,
+                "installLazygit": false,
+                "installNvim": false,
+                "installClaudeCode": true,
+                "installCodex": false
+            }
+        }
+    },
+    "codex-only": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+        "features": {
+            "devenv": {
+                "installTmux": false,
+                "installLazygit": false,
+                "installNvim": false,
+                "installClaudeCode": false,
+                "installCodex": true
             }
         }
     }


### PR DESCRIPTION
Add optional installation of Claude Code CLI and OpenAI Codex CLI:
- Add installClaudeCode and installCodex options (default: true)
- Claude Code installs via official install script
- Codex installs via npm (skips with warning if npm unavailable)
- Both tools skip installation if already present

Tests disable these tools by default to avoid CI issues with external services. Dedicated opt-in scenarios added for manual testing.