### PR TITLE
chore(devenv): bump version to 1.1.0

### DIFF
--- a/src/devenv/devcontainer-feature.json
+++ b/src/devenv/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "devenv",
     "id": "devenv",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, and neovim (with ripgrep, fd, fzf).",
     "options": {
         "installTmux": {


### PR DESCRIPTION
## Summary
- Bump devenv feature version to 1.1.0 to force a new GHCR tag
- This ensures Claude Code and Codex installation support is properly published

## Context
The previous release kept version 1.0.0, causing GHCR to serve cached content without the new features.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)