### PR TITLE
feat(devenv): add opencode AI coding assistant

### DIFF
--- a/src/devenv/devcontainer-feature.json
+++ b/src/devenv/devcontainer-feature.json
@@ -1,8 +1,8 @@
 {
     "name": "devenv",
     "id": "devenv",
-    "version": "1.6.0",
-    "description": "A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, and takt.",
+    "version": "1.7.0",
+    "description": "A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, takt, and opencode.",
     "options": {
         "installTmux": {
             "type": "boolean",
@@ -52,6 +52,11 @@
         "installTakt": {
             "type": "boolean",
             "description": "Install takt (task runner by nrslib)",
+            "default": true
+        },
+        "installOpencode": {
+            "type": "boolean",
+            "description": "Install opencode (AI coding assistant)",
             "default": true
         }
     }

--- a/src/devenv/install.sh
+++ b/src/devenv/install.sh
@@ -13,6 +13,7 @@ INSTALL_CLAUDE_CODE="${INSTALLCLAUDECODE:-true}"
 INSTALL_CODEX="${INSTALLCODEX:-true}"
 INSTALL_GH="${INSTALLGH:-true}"
 INSTALL_TAKT="${INSTALLTAKT:-true}"
+INSTALL_OPENCODE="${INSTALLOPENCODE:-true}"
 TMUX_VERSION="${TMUXVERSION:-latest}"
 LAZYGIT_VERSION="${LAZYGITVERSION:-latest}"
 NVIM_VERSION="${NVIMVERSION:-latest}"
@@ -547,6 +548,44 @@ install_takt() {
     return 0
 }
 
+# Install opencode
+install_opencode() {
+    if [ "$INSTALL_OPENCODE" != "true" ]; then
+        echo "Skipping opencode installation (disabled)"
+        return 0
+    fi
+
+    echo "Installing opencode..."
+
+    # Check if opencode is already installed (check as remote user first)
+    if [ "$REMOTE_USER" != "root" ]; then
+        if su - "$REMOTE_USER" -c "command -v opencode" &>/dev/null; then
+            echo "opencode is already installed, skipping"
+            return 0
+        fi
+    elif command -v opencode &>/dev/null; then
+        echo "opencode is already installed, skipping"
+        return 0
+    fi
+
+    # Install as the remote user so binaries go to their home directory
+    if [ "$REMOTE_USER" != "root" ]; then
+        if su - "$REMOTE_USER" -c "curl -fsSL https://opencode.ai/install | bash"; then
+            echo "opencode installed successfully for user $REMOTE_USER"
+        else
+            echo "WARNING: Failed to install opencode" >&2
+        fi
+    else
+        if curl -fsSL https://opencode.ai/install | bash; then
+            echo "opencode installed successfully"
+        else
+            echo "WARNING: Failed to install opencode" >&2
+        fi
+    fi
+
+    return 0
+}
+
 # Main installation
 main() {
     echo "Starting devenv feature installation..."
@@ -559,6 +598,7 @@ main() {
     echo "  INSTALL_CODEX=$INSTALL_CODEX"
     echo "  INSTALL_GH=$INSTALL_GH"
     echo "  INSTALL_TAKT=$INSTALL_TAKT"
+    echo "  INSTALL_OPENCODE=$INSTALL_OPENCODE"
     echo "  TMUX_VERSION=$TMUX_VERSION"
     echo "  LAZYGIT_VERSION=$LAZYGIT_VERSION"
     echo "  NVIM_VERSION=$NVIM_VERSION"
@@ -578,6 +618,7 @@ main() {
     install_codex
     install_gh
     install_takt
+    install_opencode
 
     echo "devenv feature installation complete"
 }

--- a/test/devenv/opencode-only.sh
+++ b/test/devenv/opencode-only.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+# Test opencode-only installation - only opencode should be installed
+echo "Testing opencode-only installation..."
+
+# Test opencode (should be installed)
+if command -v opencode &>/dev/null; then
+    echo "PASS: opencode is installed"
+else
+    echo "FAIL: opencode is not installed"
+    exit 1
+fi
+
+# Test tmux (should NOT be installed)
+if command -v tmux &>/dev/null; then
+    echo "FAIL: tmux should not be installed"
+    exit 1
+else
+    echo "PASS: tmux is not installed (as expected)"
+fi
+
+# Test lazygit (should NOT be installed)
+if command -v lazygit &>/dev/null; then
+    echo "FAIL: lazygit should not be installed"
+    exit 1
+else
+    echo "PASS: lazygit is not installed (as expected)"
+fi
+
+# Test neovim (should NOT be installed)
+if command -v nvim &>/dev/null; then
+    echo "FAIL: nvim should not be installed"
+    exit 1
+else
+    echo "PASS: nvim is not installed (as expected)"
+fi
+
+# Test Claude Code (should NOT be installed)
+if command -v claude &>/dev/null; then
+    echo "FAIL: claude should not be installed"
+    exit 1
+else
+    echo "PASS: claude is not installed (as expected)"
+fi
+
+# Test codex (should NOT be installed)
+if command -v codex &>/dev/null; then
+    echo "FAIL: codex should not be installed"
+    exit 1
+else
+    echo "PASS: codex is not installed (as expected)"
+fi
+
+echo "All tests passed!"

--- a/test/devenv/scenarios.json
+++ b/test/devenv/scenarios.json
@@ -4,7 +4,8 @@
         "features": {
             "devenv": {
                 "installClaudeCode": false,
-                "installCodex": false
+                "installCodex": false,
+                "installOpencode": false
             }
         }
     },
@@ -15,7 +16,8 @@
                 "installLazygit": false,
                 "installNvim": false,
                 "installClaudeCode": false,
-                "installCodex": false
+                "installCodex": false,
+                "installOpencode": false
             }
         }
     },
@@ -26,7 +28,8 @@
                 "installTmux": false,
                 "installNvim": false,
                 "installClaudeCode": false,
-                "installCodex": false
+                "installCodex": false,
+                "installOpencode": false
             }
         }
     },
@@ -37,7 +40,8 @@
                 "installTmux": false,
                 "installLazygit": false,
                 "installClaudeCode": false,
-                "installCodex": false
+                "installCodex": false,
+                "installOpencode": false
             }
         }
     },
@@ -49,7 +53,8 @@
                 "installLazygit": false,
                 "installNvim": false,
                 "installClaudeCode": false,
-                "installCodex": false
+                "installCodex": false,
+                "installOpencode": false
             }
         }
     },
@@ -61,7 +66,8 @@
                 "lazygitVersion": "0.40.2",
                 "nvimVersion": "v0.10.4",
                 "installClaudeCode": false,
-                "installCodex": false
+                "installCodex": false,
+                "installOpencode": false
             }
         }
     },
@@ -73,7 +79,8 @@
                 "installLazygit": false,
                 "installNvim": false,
                 "installClaudeCode": true,
-                "installCodex": false
+                "installCodex": false,
+                "installOpencode": false
             }
         }
     },
@@ -85,7 +92,8 @@
                 "installLazygit": false,
                 "installNvim": false,
                 "installClaudeCode": false,
-                "installCodex": true
+                "installCodex": true,
+                "installOpencode": false
             }
         }
     },
@@ -98,7 +106,22 @@
                 "installNvim": false,
                 "installClaudeCode": false,
                 "installCodex": false,
-                "installTakt": true
+                "installTakt": true,
+                "installOpencode": false
+            }
+        }
+    },
+    "opencode-only": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "devenv": {
+                "installTmux": false,
+                "installLazygit": false,
+                "installNvim": false,
+                "installClaudeCode": false,
+                "installCodex": false,
+                "installTakt": false,
+                "installOpencode": true
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add `installOpencode` option to the devenv feature (default: `true`)
- Installs opencode via `curl -fsSL https://opencode.ai/install | bash` as the remote user
- Follows the same per-user install pattern as Claude Code
- Bumps devenv feature version to 1.7.0

## Test plan
- [ ] `opencode-only` scenario passes: opencode installed, other tools not installed
- [ ] Existing scenarios unaffected (`installOpencode: false` added to all)
- [ ] `all-disabled` scenario still passes with opencode disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)