### PR TITLE
feat(devenv): add rtk (Rust Token Killer)

### DIFF
--- a/src/devenv/devcontainer-feature.json
+++ b/src/devenv/devcontainer-feature.json
@@ -1,8 +1,8 @@
 {
     "name": "devenv",
     "id": "devenv",
-    "version": "1.9.0",
-    "description": "A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, takt, opencode, gemini, and fdsx.",
+    "version": "1.10.0",
+    "description": "A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, takt, opencode, gemini, fdsx, and rtk.",
     "options": {
         "installTmux": {
             "type": "boolean",
@@ -67,6 +67,11 @@
         "installFdsx": {
             "type": "boolean",
             "description": "Install fdsx (fast data serialization tool)",
+            "default": true
+        },
+        "installRtk": {
+            "type": "boolean",
+            "description": "Install rtk (Rust Token Killer - token-optimized CLI proxy)",
             "default": true
         }
     }

--- a/src/devenv/install.sh
+++ b/src/devenv/install.sh
@@ -16,6 +16,7 @@ INSTALL_TAKT="${INSTALLTAKT:-true}"
 INSTALL_OPENCODE="${INSTALLOPENCODE:-true}"
 INSTALL_GEMINI="${INSTALLGEMINI:-true}"
 INSTALL_FDSX="${INSTALLFDSX:-true}"
+INSTALL_RTK="${INSTALLRTK:-true}"
 TMUX_VERSION="${TMUXVERSION:-latest}"
 LAZYGIT_VERSION="${LAZYGITVERSION:-latest}"
 NVIM_VERSION="${NVIMVERSION:-latest}"
@@ -695,6 +696,44 @@ install_fdsx() {
     return 0
 }
 
+# Install rtk (Rust Token Killer)
+install_rtk() {
+    if [ "$INSTALL_RTK" != "true" ]; then
+        echo "Skipping rtk installation (disabled)"
+        return 0
+    fi
+
+    echo "Installing rtk..."
+
+    # Check if rtk is already installed (check as remote user first)
+    if [ "$REMOTE_USER" != "root" ]; then
+        if su - "$REMOTE_USER" -c "command -v rtk" &>/dev/null; then
+            echo "rtk is already installed, skipping"
+            return 0
+        fi
+    elif command -v rtk &>/dev/null; then
+        echo "rtk is already installed, skipping"
+        return 0
+    fi
+
+    # Install as the remote user so binaries go to their home directory
+    if [ "$REMOTE_USER" != "root" ]; then
+        if su - "$REMOTE_USER" -c "curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh"; then
+            echo "rtk installed successfully for user $REMOTE_USER"
+        else
+            echo "WARNING: Failed to install rtk" >&2
+        fi
+    else
+        if curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh; then
+            echo "rtk installed successfully"
+        else
+            echo "WARNING: Failed to install rtk" >&2
+        fi
+    fi
+
+    return 0
+}
+
 # Main installation
 main() {
     echo "Starting devenv feature installation..."
@@ -710,6 +749,7 @@ main() {
     echo "  INSTALL_OPENCODE=$INSTALL_OPENCODE"
     echo "  INSTALL_GEMINI=$INSTALL_GEMINI"
     echo "  INSTALL_FDSX=$INSTALL_FDSX"
+    echo "  INSTALL_RTK=$INSTALL_RTK"
     echo "  TMUX_VERSION=$TMUX_VERSION"
     echo "  LAZYGIT_VERSION=$LAZYGIT_VERSION"
     echo "  NVIM_VERSION=$NVIM_VERSION"
@@ -732,6 +772,7 @@ main() {
     install_opencode
     install_gemini
     install_fdsx
+    install_rtk
 
     echo "devenv feature installation complete"
 }

--- a/test/devenv/rtk-only.sh
+++ b/test/devenv/rtk-only.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Test rtk-only installation
+echo "Testing rtk-only installation..."
+
+# Test rtk
+if command -v rtk &>/dev/null; then
+    echo "PASS: rtk is installed"
+else
+    echo "FAIL: rtk is not installed"
+    exit 1
+fi
+
+echo "All tests passed!"

--- a/test/devenv/scenarios.json
+++ b/test/devenv/scenarios.json
@@ -124,5 +124,20 @@
                 "installOpencode": true
             }
         }
+    },
+    "rtk-only": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "devenv": {
+                "installTmux": false,
+                "installLazygit": false,
+                "installNvim": false,
+                "installClaudeCode": false,
+                "installCodex": false,
+                "installTakt": false,
+                "installOpencode": false,
+                "installRtk": true
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `installRtk` option to the devenv feature for installing [rtk](https://github.com/rtk-ai/rtk), a token-optimized CLI proxy
- Installs via official install script (`curl -fsSL ... | sh`), following the same pattern as claude-code and opencode
- Bumps devenv version to 1.10.0

## Test plan
- [ ] Verify `rtk-only` scenario passes: `devcontainer features test -f devenv --skip-autogenerated --skip-duplicated .`
- [ ] Verify default scenario still passes with rtk included

🤖 Generated with [Claude Code](https://claude.com/claude-code)