### PR TITLE
docs: update devenv README options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,188 +1,102 @@
-# Dev Container Features: Self Authoring Template
+# Dev Container Features
 
-> This repo provides a starting point and example for creating your own custom [dev container Features](https://containers.dev/implementors/features/), hosted for free on GitHub Container Registry.  The example in this repository follows the [dev container Feature distribution specification](https://containers.dev/implementors/features-distribution/).  
->
-> To provide feedback to the specification, please leave a comment [on spec issue #70](https://github.com/devcontainers/spec/issues/70). For more broad feedback regarding dev container Features, please see [spec issue #61](https://github.com/devcontainers/spec/issues/61).
+Custom [Dev Container Features](https://containers.dev/features) published to GitHub Container Registry.
 
-## Example Contents
+## Available Features
 
-This repository contains a _collection_ of two Features - `hello` and `color`. These Features serve as simple feature implementations.  Each sub-section below shows a sample `devcontainer.json` alongside example usage of the Feature.
+- [`devenv`](./src/devenv) - terminal-focused development environment with tmux, lazygit, Neovim, GitHub CLI, and AI coding CLIs.
+- [`tig`](./src/tig) - installs [`tig`](https://jonas.github.io/tig/), the text-mode interface for Git.
 
-### `hello`
+## `devenv`
 
-Running `hello` inside the built container will print the greeting provided to it via its `greeting` option.
+A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, Claude Code, Codex, opencode, Gemini CLI, fdsx, rtk, and pi.
 
-```jsonc
-{
-    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-    "features": {
-        "ghcr.io/devcontainers/feature-starter/hello:1": {
-            "greeting": "Hello"
-        }
-    }
-}
-```
-
-```bash
-$ hello
-
-Hello, user.
-```
-
-### `color`
-
-Running `color` inside the built container will print your favorite color to standard out.
+### Example Usage
 
 ```jsonc
 {
-    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-    "features": {
-        "ghcr.io/devcontainers/feature-starter/color:1": {
-            "favorite": "green"
-        }
-    }
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/kenfdev/devcontainer-feature/devenv:1": {}
+  }
 }
 ```
 
-```bash
-$ color
+Disable individual tools or pin supported tool versions as needed:
 
-my favorite color is green
+```jsonc
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/kenfdev/devcontainer-feature/devenv:1": {
+      "installTmux": true,
+      "tmuxVersion": "3.4",
+      "installLazygit": true,
+      "lazygitVersion": "0.40.2",
+      "installNvim": true,
+      "nvimVersion": "0.9.5",
+      "installClaudeCode": true,
+      "installCodex": true,
+      "installGh": true,
+      "installOpencode": true,
+      "installGemini": true,
+      "installFdsx": true,
+      "installRtk": true,
+      "installPi": true
+    }
+  }
+}
 ```
-
-## Repo and Feature Structure
-
-Similar to the [`devcontainers/features`](https://github.com/devcontainers/features) repo, this repository has a `src` folder.  Each Feature has its own sub-folder, containing at least a `devcontainer-feature.json` and an entrypoint script `install.sh`. 
-
-```
-├── src
-│   ├── hello
-│   │   ├── devcontainer-feature.json
-│   │   └── install.sh
-│   ├── color
-│   │   ├── devcontainer-feature.json
-│   │   └── install.sh
-|   ├── ...
-│   │   ├── devcontainer-feature.json
-│   │   └── install.sh
-...
-```
-
-An [implementing tool](https://containers.dev/supporting#tools) will composite [the documented dev container properties](https://containers.dev/implementors/features/#devcontainer-feature-json-properties) from the feature's `devcontainer-feature.json` file, and execute in the `install.sh` entrypoint script in the container during build time.  Implementing tools are also free to process attributes under the `customizations` property as desired.
 
 ### Options
 
-All available options for a Feature should be declared in the `devcontainer-feature.json`.  The syntax for the `options` property can be found in the [devcontainer Feature json properties reference](https://containers.dev/implementors/features/#devcontainer-feature-json-properties).
+| Option | Description | Type | Default |
+| --- | --- | --- | --- |
+| `installTmux` | Install tmux terminal multiplexer | boolean | `true` |
+| `installLazygit` | Install lazygit terminal UI for Git | boolean | `true` |
+| `installNvim` | Install neovim and supporting tools (ripgrep, fd, fzf) | boolean | `true` |
+| `tmuxVersion` | tmux version to install (e.g., `3.4`, `latest`) | string | `latest` |
+| `lazygitVersion` | lazygit version to install (e.g., `0.40.2`, `latest`) | string | `latest` |
+| `nvimVersion` | neovim version to install (e.g., `0.9.5`, `latest`) | string | `latest` |
+| `installClaudeCode` | Install Claude Code CLI (AI coding assistant) | boolean | `true` |
+| `installCodex` | Install OpenAI Codex CLI (requires npm) | boolean | `true` |
+| `installGh` | Install GitHub CLI (gh) | boolean | `true` |
+| `installOpencode` | Install opencode (AI coding assistant) | boolean | `true` |
+| `installGemini` | Install Gemini CLI (Google AI coding assistant) | boolean | `true` |
+| `installFdsx` | Install fdsx | boolean | `true` |
+| `installRtk` | Install rtk (Rust Token Killer - token-optimized CLI proxy) | boolean | `true` |
+| `installPi` | Install pi coding agent | boolean | `true` |
 
-For example, the `color` feature provides an enum of three possible options (`red`, `gold`, `green`).  If no option is provided in a user's `devcontainer.json`, the value is set to "red".
+## `tig`
+
+### Example Usage
 
 ```jsonc
 {
-    // ...
-    "options": {
-        "favorite": {
-            "type": "string",
-            "enum": [
-                "red",
-                "gold",
-                "green"
-            ],
-            "default": "red",
-            "description": "Choose your favorite color."
-        }
-    }
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/kenfdev/devcontainer-feature/tig:1": {}
+  }
 }
 ```
 
-Options are exported as Feature-scoped environment variables.  The option name is captialized and sanitized according to [option resolution](https://containers.dev/implementors/features/#option-resolution).
+### Options
+
+| Option | Description | Type | Default |
+| --- | --- | --- | --- |
+| `customprefix` | The prefix to use where to install tig | string | `/usr/local` |
+
+## Development
 
 ```bash
-#!/bin/bash
+# Run autogenerated tests for a feature
+devcontainer features test --skip-scenarios -f devenv -i mcr.microsoft.com/devcontainers/base:ubuntu .
 
-echo "Activating feature 'color'"
-echo "The provided favorite color is: ${FAVORITE}"
+# Run scenario-based tests only
+devcontainer features test -f devenv --skip-autogenerated --skip-duplicated .
 
-...
+# Run full test suite
+devcontainer features test
 ```
 
-## Distributing Features
-
-### Versioning
-
-Features are individually versioned by the `version` attribute in a Feature's `devcontainer-feature.json`.  Features are versioned according to the semver specification. More details can be found in [the dev container Feature specification](https://containers.dev/implementors/features/#versioning).
-
-### Publishing
-
-> NOTE: The Distribution spec can be [found here](https://containers.dev/implementors/features-distribution/).  
->
-> While any registry [implementing the OCI Distribution spec](https://github.com/opencontainers/distribution-spec) can be used, this template will leverage GHCR (GitHub Container Registry) as the backing registry.
-
-Features are meant to be easily sharable units of dev container configuration and installation code.  
-
-This repo contains a **GitHub Action** [workflow](.github/workflows/release.yaml) that will publish each Feature to GHCR. 
-
-*Allow GitHub Actions to create and approve pull requests* should be enabled in the repository's `Settings > Actions > General > Workflow permissions` for auto generation of `src/<feature>/README.md` per Feature (which merges any existing `src/<feature>/NOTES.md`).
-
-By default, each Feature will be prefixed with the `<owner/<repo>` namespace.  For example, the two Features in this repository can be referenced in a `devcontainer.json` with:
-
-```
-ghcr.io/devcontainers/feature-starter/color:1
-ghcr.io/devcontainers/feature-starter/hello:1
-```
-
-The provided GitHub Action will also publish a third "metadata" package with just the namespace, eg: `ghcr.io/devcontainers/feature-starter`.  This contains information useful for tools aiding in Feature discovery.
-
-'`devcontainers/feature-starter`' is known as the feature collection namespace.
-
-### Marking Feature Public
-
-Note that by default, GHCR packages are marked as `private`.  To stay within the free tier, Features need to be marked as `public`.
-
-This can be done by navigating to the Feature's "package settings" page in GHCR, and setting the visibility to 'public`.  The URL may look something like:
-
-```
-https://github.com/users/<owner>/packages/container/<repo>%2F<featureName>/settings
-```
-
-<img width="669" alt="image" src="https://user-images.githubusercontent.com/23246594/185244705-232cf86a-bd05-43cb-9c25-07b45b3f4b04.png">
-
-### Adding Features to the Index
-
-If you'd like your Features to appear in our [public index](https://containers.dev/features) so that other community members can find them, you can do the following:
-
-* Go to [github.com/devcontainers/devcontainers.github.io](https://github.com/devcontainers/devcontainers.github.io)
-     * This is the GitHub repo backing the [containers.dev](https://containers.dev/) spec site
-* Open a PR to modify the [collection-index.yml](https://github.com/devcontainers/devcontainers.github.io/blob/gh-pages/_data/collection-index.yml) file
-
-This index is from where [supporting tools](https://containers.dev/supporting) like [VS Code Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and [GitHub Codespaces](https://github.com/features/codespaces) surface Features for their dev container creation UI.
-
-#### Using private Features in Codespaces
-
-For any Features hosted in GHCR that are kept private, the `GITHUB_TOKEN` access token in your environment will need to have `package:read` and `contents:read` for the associated repository.
-
-Many implementing tools use a broadly scoped access token and will work automatically.  GitHub Codespaces uses repo-scoped tokens, and therefore you'll need to add the permissions in `devcontainer.json`
-
-An example `devcontainer.json` can be found below.
-
-```jsonc
-{
-    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-    "features": {
-     "ghcr.io/my-org/private-features/hello:1": {
-            "greeting": "Hello"
-        }
-    },
-    "customizations": {
-        "codespaces": {
-            "repositories": {
-                "my-org/private-features": {
-                    "permissions": {
-                        "packages": "read",
-                        "contents": "read"
-                    }
-                }
-            }
-        }
-    }
-}
-```
+Feature metadata lives in `src/<feature>/devcontainer-feature.json`, install scripts live in `src/<feature>/install.sh`, and feature README files are generated from metadata.


### PR DESCRIPTION
## Summary
- Replace starter-template README content with project-specific feature documentation
- Document the latest devenv options, including AI CLI and pi toggles
- Add current usage examples and development commands

## Testing
- Not run (documentation-only change)