### PR TITLE
Update devenv install defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Custom [Dev Container Features](https://containers.dev/features) published to Gi
 
 ## `devenv`
 
-A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, Claude Code, Codex, opencode, Gemini CLI, fdsx, rtk, and pi.
+A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, Claude Code, Codex, opencode, fdsx, rtk, and pi.
 
 ### Example Usage
 
@@ -38,8 +38,7 @@ Disable individual tools or pin supported tool versions as needed:
       "installClaudeCode": true,
       "installCodex": true,
       "installGh": true,
-      "installOpencode": true,
-      "installGemini": true,
+      "installOpencode": false,
       "installFdsx": true,
       "installRtk": true,
       "installPi": true
@@ -61,8 +60,7 @@ Disable individual tools or pin supported tool versions as needed:
 | `installClaudeCode` | Install Claude Code CLI (AI coding assistant) | boolean | `true` |
 | `installCodex` | Install OpenAI Codex CLI (requires npm) | boolean | `true` |
 | `installGh` | Install GitHub CLI (gh) | boolean | `true` |
-| `installOpencode` | Install opencode (AI coding assistant) | boolean | `true` |
-| `installGemini` | Install Gemini CLI (Google AI coding assistant) | boolean | `true` |
+| `installOpencode` | Install opencode (AI coding assistant) | boolean | `false` |
 | `installFdsx` | Install fdsx | boolean | `true` |
 | `installRtk` | Install rtk (Rust Token Killer - token-optimized CLI proxy) | boolean | `true` |
 | `installPi` | Install pi coding agent | boolean | `true` |

--- a/src/devenv/README.md
+++ b/src/devenv/README.md
@@ -1,7 +1,7 @@
 
 # devenv (devenv)
 
-A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, opencode, gemini, [fdsx](https://github.com/kenfdev/fdsx), rtk, and pi.
+A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, opencode, [fdsx](https://github.com/kenfdev/fdsx), rtk, and pi.
 
 ## Example Usage
 
@@ -24,8 +24,7 @@ A dev container feature that bundles essential terminal-based development tools:
 | installClaudeCode | Install Claude Code CLI (AI coding assistant) | boolean | true |
 | installCodex | Install OpenAI Codex CLI (requires npm) | boolean | true |
 | installGh | Install GitHub CLI (gh) | boolean | true |
-| installOpencode | Install opencode (AI coding assistant) | boolean | true |
-| installGemini | Install Gemini CLI (Google AI coding assistant) | boolean | true |
+| installOpencode | Install opencode (AI coding assistant) | boolean | false |
 | installFdsx | Install [fdsx](https://github.com/kenfdev/fdsx) | boolean | true |
 | installRtk | Install rtk (Rust Token Killer - token-optimized CLI proxy) | boolean | true |
 | installPi | Install pi coding agent | boolean | true |

--- a/src/devenv/devcontainer-feature.json
+++ b/src/devenv/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "devenv",
     "id": "devenv",
-    "version": "1.12.2",
+    "version": "1.12.3",
     "description": "A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, opencode, fdsx, rtk, and pi.",
     "options": {
         "installTmux": {

--- a/src/devenv/devcontainer-feature.json
+++ b/src/devenv/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "devenv",
     "id": "devenv",
-    "version": "1.12.1",
+    "version": "1.12.2",
     "description": "A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, opencode, fdsx, rtk, and pi.",
     "options": {
         "installTmux": {

--- a/src/devenv/devcontainer-feature.json
+++ b/src/devenv/devcontainer-feature.json
@@ -1,8 +1,8 @@
 {
     "name": "devenv",
     "id": "devenv",
-    "version": "1.12.0",
-    "description": "A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, opencode, gemini, fdsx, rtk, and pi.",
+    "version": "1.12.1",
+    "description": "A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, opencode, fdsx, rtk, and pi.",
     "options": {
         "installTmux": {
             "type": "boolean",
@@ -52,12 +52,7 @@
         "installOpencode": {
             "type": "boolean",
             "description": "Install opencode (AI coding assistant)",
-            "default": true
-        },
-        "installGemini": {
-            "type": "boolean",
-            "description": "Install Gemini CLI (Google AI coding assistant)",
-            "default": true
+            "default": false
         },
         "installFdsx": {
             "type": "boolean",

--- a/src/devenv/install.sh
+++ b/src/devenv/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # devenv feature install script
 # Installs tmux, lazygit, neovim (with supporting tools: ripgrep, fd, fzf), gh,
-# Claude Code, Codex, opencode, Gemini CLI, fdsx, rtk, and pi
+# Claude Code, Codex, opencode, fdsx, rtk, and pi
 
 # Options (passed as environment variables)
 INSTALL_TMUX="${INSTALLTMUX:-true}"
@@ -12,8 +12,7 @@ INSTALL_NVIM="${INSTALLNVIM:-true}"
 INSTALL_CLAUDE_CODE="${INSTALLCLAUDECODE:-true}"
 INSTALL_CODEX="${INSTALLCODEX:-true}"
 INSTALL_GH="${INSTALLGH:-true}"
-INSTALL_OPENCODE="${INSTALLOPENCODE:-true}"
-INSTALL_GEMINI="${INSTALLGEMINI:-true}"
+INSTALL_OPENCODE="${INSTALLOPENCODE:-false}"
 INSTALL_FDSX="${INSTALLFDSX:-true}"
 INSTALL_RTK="${INSTALLRTK:-true}"
 INSTALL_PI="${INSTALLPI:-true}"
@@ -550,46 +549,6 @@ install_opencode() {
     return 0
 }
 
-# Install Gemini CLI
-install_gemini() {
-    if [ "$INSTALL_GEMINI" != "true" ]; then
-        echo "Skipping Gemini CLI installation (disabled)"
-        return 0
-    fi
-
-    echo "Installing Gemini CLI..."
-
-    # Check if gemini is already installed (check as remote user first)
-    if [ "$REMOTE_USER" != "root" ]; then
-        if su - "$REMOTE_USER" -c "command -v gemini" &>/dev/null; then
-            echo "Gemini CLI is already installed, skipping"
-            return 0
-        fi
-    elif command -v gemini &>/dev/null; then
-        echo "Gemini CLI is already installed, skipping"
-        return 0
-    fi
-
-    # Try installing as remote user if they have npm available
-    if [ "$REMOTE_USER" != "root" ] && su - "$REMOTE_USER" -c "command -v npm" &>/dev/null; then
-        if su - "$REMOTE_USER" -c "npm install -g @google/gemini-cli"; then
-            echo "Gemini CLI installed successfully for user $REMOTE_USER"
-        else
-            echo "WARNING: Failed to install Gemini CLI" >&2
-        fi
-    elif command -v npm &>/dev/null; then
-        # Fallback: install as root (system-wide)
-        if npm install -g @google/gemini-cli; then
-            echo "Gemini CLI installed successfully"
-        else
-            echo "WARNING: Failed to install Gemini CLI" >&2
-        fi
-    else
-        echo "WARNING: npm is not installed, skipping Gemini CLI installation" >&2
-    fi
-
-    return 0
-}
 
 # Install fdsx via uv tool
 install_fdsx() {
@@ -787,7 +746,6 @@ main() {
     echo "  INSTALL_CODEX=$INSTALL_CODEX"
     echo "  INSTALL_GH=$INSTALL_GH"
     echo "  INSTALL_OPENCODE=$INSTALL_OPENCODE"
-    echo "  INSTALL_GEMINI=$INSTALL_GEMINI"
     echo "  INSTALL_FDSX=$INSTALL_FDSX"
     echo "  INSTALL_RTK=$INSTALL_RTK"
     echo "  INSTALL_PI=$INSTALL_PI"
@@ -810,7 +768,6 @@ main() {
     install_codex
     install_gh
     install_opencode
-    install_gemini
     install_fdsx
     install_rtk
     install_pi

--- a/src/devenv/install.sh
+++ b/src/devenv/install.sh
@@ -51,8 +51,20 @@ echo "Detected architecture: $ARCH"
 # Helper function to get latest release version from GitHub
 get_latest_version() {
     local repo="$1"
+    local response
     local version
-    version=$(curl -s "https://api.github.com/repos/${repo}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+
+    if ! response=$(curl -fsSL "https://api.github.com/repos/${repo}/releases/latest"); then
+        echo "WARNING: Failed to fetch latest release metadata for ${repo}" >&2
+        return 1
+    fi
+
+    version=$(printf '%s\n' "$response" | awk -F'"' '/^[[:space:]]*"tag_name"[[:space:]]*:/ { print $4; exit }')
+    if [ -z "$version" ]; then
+        echo "WARNING: Could not parse latest release version for ${repo}" >&2
+        return 1
+    fi
+
     echo "$version"
 }
 

--- a/src/devenv/install.sh
+++ b/src/devenv/install.sh
@@ -51,18 +51,31 @@ echo "Detected architecture: $ARCH"
 # Helper function to get latest release version from GitHub
 get_latest_version() {
     local repo="$1"
-    local response
-    local version
+    local response=""
+    local latest_url=""
+    local version=""
 
-    if ! response=$(curl -fsSL "https://api.github.com/repos/${repo}/releases/latest"); then
-        echo "WARNING: Failed to fetch latest release metadata for ${repo}" >&2
-        return 1
+    # Prefer the GitHub API when available. Match the exact top-level tag_name key
+    # instead of any quoted string on the line.
+    response=$(curl -fsSL "https://api.github.com/repos/${repo}/releases/latest" 2>/dev/null || true)
+    if [ -n "$response" ]; then
+        version=$(printf '%s\n' "$response" | awk -F'"' '/^[[:space:]]*"tag_name"[[:space:]]*:/ { print $4; exit }')
     fi
 
-    version=$(printf '%s\n' "$response" | awk -F'"' '/^[[:space:]]*"tag_name"[[:space:]]*:/ { print $4; exit }')
+    # Fallback to the releases/latest redirect target. This avoids failing on
+    # transient API response shape/rate-limit issues and still yields the tag.
     if [ -z "$version" ]; then
-        echo "WARNING: Could not parse latest release version for ${repo}" >&2
-        return 1
+        latest_url=$(curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.com/${repo}/releases/latest" 2>/dev/null || true)
+        case "$latest_url" in
+            */tag/*)
+                version="${latest_url##*/tag/}"
+                version="${version%%[?#]*}"
+                ;;
+        esac
+    fi
+
+    if [ -z "$version" ]; then
+        echo "WARNING: Could not determine latest release version for ${repo}" >&2
     fi
 
     echo "$version"

--- a/test/devenv/scenarios.json
+++ b/test/devenv/scenarios.json
@@ -145,7 +145,6 @@
                 "installCodex": false,
                 "installGh": false,
                 "installOpencode": false,
-                "installGemini": false,
                 "installFdsx": false,
                 "installRtk": false,
                 "installPi": true


### PR DESCRIPTION
## Summary
- remove Gemini CLI install option and installer logic from the devenv feature
- make opencode opt-in by default
- bump the devenv feature version to 1.12.1

## Validation
- bash -n src/devenv/install.sh
- jq . src/devenv/devcontainer-feature.json
- jq . test/devenv/scenarios.json