### PR TITLE
[codex] Make tmux opt-in for devenv feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Disable individual tools or pin supported tool versions as needed:
 
 | Option | Description | Type | Default |
 | --- | --- | --- | --- |
-| `installTmux` | Install tmux terminal multiplexer | boolean | `true` |
+| `installTmux` | Install tmux terminal multiplexer | boolean | `false` |
 | `installLazygit` | Install lazygit terminal UI for Git | boolean | `true` |
 | `installNvim` | Install neovim and supporting tools (ripgrep, fd, fzf) | boolean | `true` |
 | `tmuxVersion` | tmux version to install (e.g., `3.4`, `latest`) | string | `latest` |

--- a/docs/specs/dev-spec.md
+++ b/docs/specs/dev-spec.md
@@ -32,7 +32,7 @@ All options use **camelCase** naming convention.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `installTmux` | boolean | `true` | Install tmux |
+| `installTmux` | boolean | `false` | Install tmux |
 | `installLazygit` | boolean | `true` | Install lazygit |
 | `installNvim` | boolean | `true` | Install neovim (and supporting tools: ripgrep, fd, fzf) |
 | `installPi` | boolean | `true` | Install pi coding agent |
@@ -135,7 +135,7 @@ Tests verify **binary existence only**:
 
 ### Test Scenarios
 
-1. **Default installation** - All tools with latest versions
+1. **Default installation** - Default-enabled tools with latest versions (tmux disabled by default)
 2. **Selective installation** - Only tmux enabled
 3. **Selective installation** - Only lazygit enabled
 4. **Selective installation** - Only nvim enabled
@@ -169,6 +169,7 @@ Tests verify **binary existence only**:
 ```json
 "features": {
   "ghcr.io/kenfdev/devcontainer-feature/devenv": {
+    "installTmux": true,
     "tmuxVersion": "3.4",
     "lazygitVersion": "0.40.2",
     "nvimVersion": "0.9.5"

--- a/src/devenv/README.md
+++ b/src/devenv/README.md
@@ -15,7 +15,7 @@ A dev container feature that bundles essential terminal-based development tools:
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| installTmux | Install tmux terminal multiplexer | boolean | true |
+| installTmux | Install tmux terminal multiplexer | boolean | false |
 | installLazygit | Install lazygit terminal UI for Git | boolean | true |
 | installNvim | Install neovim and supporting tools (ripgrep, fd, fzf) | boolean | true |
 | tmuxVersion | tmux version to install (e.g., '3.4', 'latest') | string | latest |

--- a/src/devenv/devcontainer-feature.json
+++ b/src/devenv/devcontainer-feature.json
@@ -1,13 +1,13 @@
 {
     "name": "devenv",
     "id": "devenv",
-    "version": "1.12.3",
+    "version": "1.12.4",
     "description": "A dev container feature that bundles essential terminal-based development tools: tmux, lazygit, neovim (with ripgrep, fd, fzf), gh, opencode, fdsx, rtk, and pi.",
     "options": {
         "installTmux": {
             "type": "boolean",
             "description": "Install tmux terminal multiplexer",
-            "default": true
+            "default": false
         },
         "installLazygit": {
             "type": "boolean",

--- a/src/devenv/install.sh
+++ b/src/devenv/install.sh
@@ -6,7 +6,7 @@ set -e
 # Claude Code, Codex, opencode, fdsx, rtk, and pi
 
 # Options (passed as environment variables)
-INSTALL_TMUX="${INSTALLTMUX:-true}"
+INSTALL_TMUX="${INSTALLTMUX:-false}"
 INSTALL_LAZYGIT="${INSTALLLAZYGIT:-true}"
 INSTALL_NVIM="${INSTALLNVIM:-true}"
 INSTALL_CLAUDE_CODE="${INSTALLCLAUDECODE:-true}"

--- a/test/devenv/default.sh
+++ b/test/devenv/default.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# Test default installation - all tools should be installed
+# Test default installation - default-enabled tools should be installed
 echo "Testing default installation..."
 
 # Test lazygit
@@ -44,12 +44,12 @@ else
     exit 1
 fi
 
-# Test tmux
+# Test tmux (disabled by default)
 if command -v tmux &>/dev/null; then
-    echo "PASS: tmux is installed"
-else
-    echo "FAIL: tmux is not installed"
+    echo "FAIL: tmux should not be installed by default"
     exit 1
+else
+    echo "PASS: tmux is not installed (as expected)"
 fi
 
 echo "All tests passed!"

--- a/test/devenv/scenarios.json
+++ b/test/devenv/scenarios.json
@@ -14,6 +14,7 @@
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
             "devenv": {
+                "installTmux": true,
                 "installLazygit": false,
                 "installNvim": false,
                 "installClaudeCode": false,
@@ -67,6 +68,7 @@
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
             "devenv": {
+                "installTmux": true,
                 "tmuxVersion": "3.4",
                 "lazygitVersion": "0.40.2",
                 "nvimVersion": "v0.10.4",

--- a/test/devenv/test.sh
+++ b/test/devenv/test.sh
@@ -11,7 +11,7 @@ set -e
 source dev-container-features-test-lib
 
 # Check core tools installed by default
-check "tmux is installed" tmux -V
+check "tmux is not installed by default" bash -c '! command -v tmux'
 check "lazygit is installed" lazygit --version
 check "nvim is installed" nvim --version
 check "gh is installed" gh --version


### PR DESCRIPTION
## Summary
- Make `installTmux` default to `false` for the `devenv` feature.
- Bump the `devenv` feature version to `1.12.4`.
- Update generated docs/spec text and tests so default installs expect tmux to be absent unless explicitly enabled.

## Impact
Users get a lighter default `devenv` install. Tmux remains available by setting `installTmux: true`.

## Validation
- Attempted `devcontainer features test --skip-scenarios -f devenv -i mcr.microsoft.com/devcontainers/base:ubuntu .`; blocked because Docker daemon is not reachable at `/var/run/docker.sock` in this environment.