### PR TITLE
[codex] fix tailscale auth key startup

### DIFF
--- a/src/tools/devcontainer-feature.json
+++ b/src/tools/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "tools",
     "id": "tools",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "A minimal dev container feature that bundles terminal-based development tools and optional Tailscale SSH access.",
     "entrypoint": "/usr/local/bin/tailscale-entrypoint.sh",
     "capAdd": [

--- a/src/tools/tailscale-entrypoint.sh
+++ b/src/tools/tailscale-entrypoint.sh
@@ -65,6 +65,12 @@ start_tailscaled() {
     wait_for_tailscaled || true
 }
 
+backend_state() {
+    tailscale --socket="${TS_SOCKET}" status --json 2>/dev/null \
+        | sed -n 's/.*"BackendState":[[:space:]]*"\([^"]*\)".*/\1/p' \
+        | head -n 1
+}
+
 has_existing_state() {
     find "${TS_STATE_DIR}" -mindepth 1 -type f -print -quit 2>/dev/null | grep -q .
 }
@@ -121,29 +127,40 @@ reset_tailscale_state() {
 }
 
 bring_tailscale_up() {
+    local state
+    state="$(backend_state || true)"
+
+    if [ "${state}" = "Running" ]; then
+        if run_tailscale_up ""; then
+            return 0
+        fi
+        log "WARNING: Failed to refresh Tailscale settings with existing login"
+    fi
+
+    if [ -n "${AUTH_KEY}" ]; then
+        if run_tailscale_up "${AUTH_KEY}"; then
+            return 0
+        fi
+
+        if [ "${TS_RESET_ON_AUTH_FAILURE}" = "true" ]; then
+            reset_tailscale_state
+            run_tailscale_up "${AUTH_KEY}" || log "WARNING: Tailscale authentication failed after reset; continuing container startup"
+            return 0
+        fi
+
+        log "WARNING: Tailscale authentication failed; continuing container startup"
+        return 0
+    fi
+
     if has_existing_state; then
         if run_tailscale_up ""; then
             return 0
         fi
         log "WARNING: Failed to bring Tailscale up with existing state"
-    fi
-
-    if [ -z "${AUTH_KEY}" ]; then
-        log "WARNING: No TS_AUTH_KEY or TS_AUTHKEY provided; container will continue without joining Tailscale"
         return 0
     fi
 
-    if run_tailscale_up "${AUTH_KEY}"; then
-        return 0
-    fi
-
-    if [ "${TS_RESET_ON_AUTH_FAILURE}" = "true" ]; then
-        reset_tailscale_state
-        run_tailscale_up "${AUTH_KEY}" || log "WARNING: Tailscale authentication failed after reset; continuing container startup"
-        return 0
-    fi
-
-    log "WARNING: Tailscale authentication failed; continuing container startup"
+    log "WARNING: No TS_AUTH_KEY or TS_AUTHKEY provided; container will continue without joining Tailscale"
 }
 
 ensure_tun_device

--- a/test/tools/tailscale-entrypoint-auth-key-first.sh
+++ b/test/tools/tailscale-entrypoint-auth-key-first.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    if [ -x /opt/homebrew/bin/bash ]; then
+        exec /opt/homebrew/bin/bash "$0" "$@"
+    fi
+
+    echo "FAIL: Bash 4 or newer is required for this test" >&2
+    exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+    if [ -f "${tmpdir}/tailscaled.pid" ]; then
+        kill "$(cat "${tmpdir}/tailscaled.pid")" >/dev/null 2>&1 || true
+    fi
+    rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+mkdir -p "${tmpdir}/bin" "${tmpdir}/state"
+
+cat > "${tmpdir}/bin/mkdir" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 2 ] && [ "$1" = "-p" ] && [ "$2" = "/dev/net" ]; then
+    exit 0
+fi
+
+exec /bin/mkdir "$@"
+EOF
+
+cat > "${tmpdir}/bin/mknod" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+
+cat > "${tmpdir}/bin/tailscaled" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_dir=""
+for arg in "$@"; do
+    case "${arg}" in
+        --statedir=*)
+            state_dir="${arg#--statedir=}"
+            ;;
+    esac
+done
+
+mkdir -p "${state_dir}"
+touch "${state_dir}/tailscaled.state"
+echo "$$" > "${TEST_TMPDIR}/tailscaled.pid"
+
+while true; do
+    sleep 60
+done
+EOF
+
+cat > "${tmpdir}/bin/tailscale" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args=("$@")
+command_name=""
+for arg in "${args[@]}"; do
+    case "${arg}" in
+        --socket=*)
+            ;;
+        status|up|logout)
+            command_name="${arg}"
+            break
+            ;;
+    esac
+done
+
+case "${command_name}" in
+    status)
+        touch "${TEST_TMPDIR}/state/pre-login.state"
+        exit 0
+        ;;
+    up)
+        printf '%s\n' "$*" >> "${TEST_TMPDIR}/tailscale-up.log"
+        exit 0
+        ;;
+    logout)
+        exit 0
+        ;;
+    *)
+        echo "unexpected tailscale invocation: $*" >&2
+        exit 1
+        ;;
+esac
+EOF
+
+chmod +x "${tmpdir}/bin/mkdir" "${tmpdir}/bin/mknod" "${tmpdir}/bin/tailscaled" "${tmpdir}/bin/tailscale"
+
+PATH="${tmpdir}/bin:${PATH}" \
+TEST_TMPDIR="${tmpdir}" \
+TS_STATE_DIR="${tmpdir}/state" \
+TS_SOCKET="${tmpdir}/tailscaled.sock" \
+TS_AUTH_KEY="tskey-auth-test" \
+TS_ENABLE_SSH=false \
+TS_TAG= \
+    "${BASH}" "${repo_root}/src/tools/tailscale-entrypoint.sh" true
+
+if ! grep -q -- '--auth-key=tskey-auth-test' "${tmpdir}/tailscale-up.log"; then
+    echo "FAIL: first tailscale up did not use TS_AUTH_KEY when pre-login state existed"
+    echo "Recorded invocations:"
+    cat "${tmpdir}/tailscale-up.log"
+    exit 1
+fi
+
+echo "PASS: tailscale entrypoint uses TS_AUTH_KEY before state-only login"


### PR DESCRIPTION
## Summary

Fix the `tools` feature Tailscale entrypoint so a provided `TS_AUTH_KEY` / `TS_AUTHKEY` is attempted before falling back to state-only login when local state exists but the daemon is not already running.

## Impact

This avoids containers continuing with stale pre-login state instead of joining Tailscale with the auth key supplied at startup. The feature version is bumped to `1.3.1` so GHCR consumers receive the updated entrypoint.

## Validation

- `bash test/tools/tailscale-entrypoint-auth-key-first.sh`
- `git diff --check`

Attempted `devcontainer features test -f tools --skip-autogenerated --skip-duplicated .`; the scenario build completed, but Docker/Colima failed to launch the test container because the generated `/var/folders/...` bind source path was unavailable to the daemon.
