### PR TITLE
[codex] Add sshd support to tools feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Custom [Dev Container Features](https://containers.dev/features) published to Gi
 ## Available Features
 
 - [`devenv`](./src/devenv) - terminal-focused development environment with tmux, lazygit, Neovim, GitHub CLI, and AI coding CLIs.
-- [`tools`](./src/tools) - minimal terminal-focused tool bundle with lazygit, Neovim, GitHub CLI, AI coding CLIs, and optional Tailscale SSH access.
+- [`tools`](./src/tools) - minimal terminal-focused tool bundle with lazygit, Neovim, GitHub CLI, AI coding CLIs, Tailscale access, and optional normal SSH access.
 - [`tig`](./src/tig) - installs [`tig`](https://jonas.github.io/tig/), the text-mode interface for Git.
 
 ## `devenv`
@@ -68,7 +68,7 @@ Disable individual tools or pin supported tool versions as needed:
 
 ## `tools`
 
-A minimal dev container feature that bundles terminal-based development tools: lazygit, neovim (with ripgrep, fd, fzf), gh, Claude Code, Codex, fdsx, rtk, pi, and optional Tailscale SSH access.
+A minimal dev container feature that bundles terminal-based development tools: lazygit, neovim (with ripgrep, fd, fzf), gh, Claude Code, Codex, fdsx, rtk, pi, Tailscale access, and an optional OpenSSH server for normal SSH clients.
 
 ### Example Usage
 
@@ -103,7 +103,8 @@ Disable individual tools or pin supported tool versions as needed:
       "installFdsx": true,
       "installRtk": true,
       "installPi": true,
-      "installTailscale": true
+      "installTailscale": true,
+      "installSshd": true
     }
   }
 }
@@ -124,8 +125,9 @@ Disable individual tools or pin supported tool versions as needed:
 | `installRtk` | Install rtk (Rust Token Killer - token-optimized CLI proxy) | boolean | `true` |
 | `installPi` | Install pi coding agent | boolean | `true` |
 | `installTailscale` | Install Tailscale and configure the tools entrypoint for Tailscale SSH | boolean | `true` |
+| `installSshd` | Install and start OpenSSH server for normal SSH access | boolean | `true` |
 
-The `tools` feature metadata sets `/usr/local/bin/tailscale-entrypoint.sh` as the entrypoint and adds `NET_ADMIN`, `NET_RAW`, and `MKNOD`. For Dockerfile-only usage, set `INSTALLTAILSCALE=false` to skip Tailscale installation.
+The `tools` feature metadata sets `/usr/local/bin/tailscale-entrypoint.sh` as the entrypoint and adds `NET_ADMIN`, `NET_RAW`, and `MKNOD`. It persists Tailscale state in `/var/lib/tailscale` and SSH host keys in `/var/lib/ssh-host-keys`. For normal SSH access, provide a public key with `SSH_AUTHORIZED_KEYS` or `SSH_AUTHORIZED_KEYS_FILE`. For Dockerfile-only usage, set `INSTALLTAILSCALE=false` or `INSTALLSSHD=false` to skip either service installation.
 
 ## `tig`
 

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -1,7 +1,7 @@
 
 # tools (tools)
 
-A minimal dev container feature that bundles terminal-based development tools and optional Tailscale SSH access.
+A minimal dev container feature that bundles terminal-based development tools, Tailscale access, and an optional OpenSSH server.
 
 ## Example Usage
 
@@ -26,6 +26,7 @@ A minimal dev container feature that bundles terminal-based development tools an
 | installRtk | Install rtk (Rust Token Killer - token-optimized CLI proxy) | boolean | true |
 | installPi | Install pi coding agent | boolean | true |
 | installTailscale | Install Tailscale and configure the tools entrypoint for Tailscale SSH | boolean | true |
+| installSshd | Install and start OpenSSH server for normal SSH access | boolean | true |
 
 
 

--- a/src/tools/devcontainer-feature.json
+++ b/src/tools/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "tools",
     "id": "tools",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "A minimal dev container feature that bundles terminal-based development tools and optional Tailscale SSH access.",
     "entrypoint": "/usr/local/bin/tailscale-entrypoint.sh",
     "capAdd": [

--- a/src/tools/devcontainer-feature.json
+++ b/src/tools/devcontainer-feature.json
@@ -1,8 +1,8 @@
 {
     "name": "tools",
     "id": "tools",
-    "version": "1.3.2",
-    "description": "A minimal dev container feature that bundles terminal-based development tools and optional Tailscale SSH access.",
+    "version": "1.4.0",
+    "description": "A minimal dev container feature that bundles terminal-based development tools, Tailscale access, and an optional OpenSSH server.",
     "entrypoint": "/usr/local/bin/tailscale-entrypoint.sh",
     "capAdd": [
         "NET_ADMIN",
@@ -14,12 +14,19 @@
             "source": "tools-tailscale-state",
             "target": "/var/lib/tailscale",
             "type": "volume"
+        },
+        {
+            "source": "tools-ssh-host-keys",
+            "target": "/var/lib/ssh-host-keys",
+            "type": "volume"
         }
     ],
     "containerEnv": {
         "TS_STATE_DIR": "/var/lib/tailscale",
         "TS_ENABLE_SSH": "true",
-        "TS_TAG": "tag:dev-container"
+        "TS_TAG": "tag:dev-container",
+        "SSHD_ENABLE": "true",
+        "SSHD_USER": "root"
     },
     "options": {
         "installLazygit": {
@@ -75,6 +82,11 @@
         "installTailscale": {
             "type": "boolean",
             "description": "Install Tailscale and configure the tools entrypoint for Tailscale SSH",
+            "default": true
+        },
+        "installSshd": {
+            "type": "boolean",
+            "description": "Install and start OpenSSH server for normal SSH access",
             "default": true
         }
     }

--- a/src/tools/install.sh
+++ b/src/tools/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # tools feature install script
 # Installs lazygit, neovim (with supporting tools: ripgrep, fd, fzf), gh,
-# Claude Code, Codex, fdsx, rtk, pi, and optional Tailscale SSH access
+# Claude Code, Codex, fdsx, rtk, pi, optional Tailscale access, and OpenSSH
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -17,6 +17,7 @@ INSTALL_FDSX="${INSTALLFDSX:-true}"
 INSTALL_RTK="${INSTALLRTK:-true}"
 INSTALL_PI="${INSTALLPI:-true}"
 INSTALL_TAILSCALE="${INSTALLTAILSCALE:-true}"
+INSTALL_SSHD="${INSTALLSSHD:-true}"
 LAZYGIT_VERSION="${LAZYGITVERSION:-latest}"
 NVIM_VERSION="${NVIMVERSION:-latest}"
 
@@ -173,6 +174,45 @@ install_tailscale() {
 
     apt-get clean
     rm -rf /var/lib/apt/lists/*
+}
+
+install_sshd() {
+    if [ "$INSTALL_SSHD" != "true" ]; then
+        echo "Skipping OpenSSH server installation (disabled)"
+        return 0
+    fi
+
+    echo "Installing OpenSSH server..."
+    if command -v apt-get &>/dev/null; then
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y --no-install-recommends openssh-server
+        apt-get clean
+        rm -rf /var/lib/apt/lists/*
+    elif command -v apk &>/dev/null; then
+        apk add --no-cache openssh-server
+    elif command -v dnf &>/dev/null; then
+        dnf install -y openssh-server
+    else
+        echo "WARNING: Could not find a supported package manager for OpenSSH server" >&2
+        return 0
+    fi
+
+    mkdir -p /run/sshd /var/lib/ssh-host-keys
+    chmod 755 /run/sshd
+
+    if [ -f /etc/ssh/sshd_config ]; then
+        sed -i \
+            -e 's/^[#[:space:]]*PermitRootLogin.*/PermitRootLogin prohibit-password/' \
+            -e 's/^[#[:space:]]*PasswordAuthentication.*/PasswordAuthentication no/' \
+            -e 's/^[#[:space:]]*PubkeyAuthentication.*/PubkeyAuthentication yes/' \
+            -e 's/^[#[:space:]]*KbdInteractiveAuthentication.*/KbdInteractiveAuthentication no/' \
+            /etc/ssh/sshd_config
+    fi
+
+    # Runtime entrypoint creates stable per-volume host keys instead of baking
+    # build-time keys into the image.
+    rm -f /etc/ssh/ssh_host_*_key /etc/ssh/ssh_host_*_key.pub
 }
 
 # Install lazygit from GitHub Releases
@@ -740,6 +780,7 @@ main() {
     echo "  INSTALL_RTK=$INSTALL_RTK"
     echo "  INSTALL_PI=$INSTALL_PI"
     echo "  INSTALL_TAILSCALE=$INSTALL_TAILSCALE"
+    echo "  INSTALL_SSHD=$INSTALL_SSHD"
     echo "  LAZYGIT_VERSION=$LAZYGIT_VERSION"
     echo "  NVIM_VERSION=$NVIM_VERSION"
 
@@ -752,6 +793,7 @@ main() {
 
     install_dependencies
     install_tailscale
+    install_sshd
     install_lazygit
     install_nvim
     install_claude_code

--- a/src/tools/tailscale-entrypoint.sh
+++ b/src/tools/tailscale-entrypoint.sh
@@ -108,6 +108,7 @@ run_tailscale_up() {
     tailscale_up_args args
 
     if [ -n "${auth_key}" ]; then
+        args+=(--reset)
         args+=(--auth-key="${auth_key}")
     fi
 

--- a/src/tools/tailscale-entrypoint.sh
+++ b/src/tools/tailscale-entrypoint.sh
@@ -10,15 +10,94 @@ TS_SOCKET="${TS_SOCKET:-/var/run/tailscale/tailscaled.sock}"
 TS_ENABLE_SSH="${TS_ENABLE_SSH:-true}"
 TS_ACCEPT_ROUTES="${TS_ACCEPT_ROUTES:-false}"
 TS_RESET_ON_AUTH_FAILURE="${TS_RESET_ON_AUTH_FAILURE:-false}"
+SSHD_ENABLE="${SSHD_ENABLE:-true}"
+SSHD_USER="${SSHD_USER:-root}"
+SSHD_HOST_KEY_DIR="${SSHD_HOST_KEY_DIR:-/var/lib/ssh-host-keys}"
+SSHD_CONFIG_DIR="${SSHD_CONFIG_DIR:-/etc/ssh}"
+SSHD_RUN_DIR="${SSHD_RUN_DIR:-/run/sshd}"
 
 AUTH_KEY="${TS_AUTH_KEY:-${TS_AUTHKEY:-}}"
 unset TS_AUTH_KEY TS_AUTHKEY
 
-if ! command -v tailscaled >/dev/null 2>&1 || ! command -v tailscale >/dev/null 2>&1; then
-    exec "$@"
-fi
-
 HOSTNAME_VALUE="${TS_HOSTNAME:-$(hostname)}"
+
+sshd_bin() {
+    if command -v sshd >/dev/null 2>&1; then
+        command -v sshd
+        return 0
+    fi
+
+    if [ -x /usr/sbin/sshd ]; then
+        echo /usr/sbin/sshd
+        return 0
+    fi
+
+    return 1
+}
+
+ensure_sshd_host_keys() {
+    mkdir -p "${SSHD_CONFIG_DIR}" "${SSHD_HOST_KEY_DIR}"
+
+    if ! find "${SSHD_HOST_KEY_DIR}" -maxdepth 1 -name 'ssh_host_*_key' -type f -print -quit 2>/dev/null | grep -q .; then
+        ssh-keygen -A
+        cp -a "${SSHD_CONFIG_DIR}"/ssh_host_*_key "${SSHD_CONFIG_DIR}"/ssh_host_*_key.pub "${SSHD_HOST_KEY_DIR}"/ 2>/dev/null || true
+    fi
+
+    local key_path key_name
+    for key_path in "${SSHD_HOST_KEY_DIR}"/ssh_host_*_key; do
+        [ -f "${key_path}" ] || continue
+        key_name="$(basename "${key_path}")"
+        ln -sf "${key_path}" "${SSHD_CONFIG_DIR}/${key_name}"
+        if [ -f "${key_path}.pub" ]; then
+            ln -sf "${key_path}.pub" "${SSHD_CONFIG_DIR}/${key_name}.pub"
+        fi
+    done
+}
+
+configure_authorized_keys() {
+    local user_home authorized_keys_file
+    user_home="$(getent passwd "${SSHD_USER}" 2>/dev/null | cut -d: -f6 || true)"
+    if [ -z "${user_home}" ]; then
+        user_home="/root"
+    fi
+
+    mkdir -p "${user_home}/.ssh"
+    chmod 700 "${user_home}/.ssh"
+    authorized_keys_file="${user_home}/.ssh/authorized_keys"
+
+    if [ -n "${SSH_AUTHORIZED_KEYS:-}" ]; then
+        printf '%s\n' "${SSH_AUTHORIZED_KEYS}" > "${authorized_keys_file}"
+    elif [ -n "${SSH_AUTHORIZED_KEYS_FILE:-}" ] && [ -r "${SSH_AUTHORIZED_KEYS_FILE}" ]; then
+        cp "${SSH_AUTHORIZED_KEYS_FILE}" "${authorized_keys_file}"
+    fi
+
+    if [ -f "${authorized_keys_file}" ]; then
+        chmod 600 "${authorized_keys_file}"
+        chown -R "${SSHD_USER}:${SSHD_USER}" "${user_home}/.ssh" 2>/dev/null || true
+    fi
+}
+
+start_sshd() {
+    local sshd_path
+
+    if [ "${SSHD_ENABLE}" != "true" ]; then
+        return 0
+    fi
+
+    if ! sshd_path="$(sshd_bin)"; then
+        return 0
+    fi
+
+    mkdir -p "${SSHD_RUN_DIR}"
+    ensure_sshd_host_keys
+    configure_authorized_keys
+
+    if pgrep -x sshd >/dev/null 2>&1; then
+        return 0
+    fi
+
+    "${sshd_path}" -D -e &
+}
 
 ensure_tun_device() {
     if [ -c /dev/net/tun ]; then
@@ -164,8 +243,12 @@ bring_tailscale_up() {
     log "WARNING: No TS_AUTH_KEY or TS_AUTHKEY provided; container will continue without joining Tailscale"
 }
 
-ensure_tun_device
-start_tailscaled
-bring_tailscale_up
+start_sshd
+
+if command -v tailscaled >/dev/null 2>&1 && command -v tailscale >/dev/null 2>&1; then
+    ensure_tun_device
+    start_tailscaled
+    bring_tailscale_up
+fi
 
 exec "$@"

--- a/test/tools/all-disabled.sh
+++ b/test/tools/all-disabled.sh
@@ -3,7 +3,7 @@ set -e
 
 echo "Testing all-disabled installation..."
 
-for tool in lazygit nvim rg fd fzf claude codex gh fdsx rtk pi tailscale tailscaled; do
+for tool in lazygit nvim rg fd fzf claude codex gh fdsx rtk pi tailscale tailscaled sshd; do
     if command -v "$tool" &>/dev/null; then
         echo "FAIL: $tool should not be installed"
         exit 1

--- a/test/tools/scenarios.json
+++ b/test/tools/scenarios.json
@@ -11,7 +11,8 @@
                 "installFdsx": false,
                 "installRtk": false,
                 "installPi": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     },
@@ -26,7 +27,8 @@
                 "installFdsx": false,
                 "installRtk": false,
                 "installPi": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     },
@@ -41,7 +43,8 @@
                 "installFdsx": false,
                 "installRtk": false,
                 "installPi": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     },
@@ -56,7 +59,8 @@
                 "installFdsx": false,
                 "installRtk": false,
                 "installPi": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     },
@@ -71,7 +75,8 @@
                 "installFdsx": false,
                 "installRtk": false,
                 "installPi": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     },
@@ -86,7 +91,8 @@
                 "installFdsx": false,
                 "installRtk": false,
                 "installPi": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     },
@@ -101,7 +107,8 @@
                 "installFdsx": false,
                 "installRtk": false,
                 "installPi": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     },
@@ -116,7 +123,8 @@
                 "installGh": false,
                 "installRtk": false,
                 "installPi": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     },
@@ -131,7 +139,8 @@
                 "installGh": false,
                 "installFdsx": false,
                 "installPi": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     },
@@ -146,7 +155,8 @@
                 "installGh": false,
                 "installFdsx": false,
                 "installRtk": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     },
@@ -161,7 +171,24 @@
                 "installGh": false,
                 "installFdsx": false,
                 "installRtk": false,
-                "installPi": false
+                "installPi": false,
+                "installSshd": false
+            }
+        }
+    },
+    "sshd-only": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "tools": {
+                "installLazygit": false,
+                "installNvim": false,
+                "installClaudeCode": false,
+                "installCodex": false,
+                "installGh": false,
+                "installFdsx": false,
+                "installRtk": false,
+                "installPi": false,
+                "installTailscale": false
             }
         }
     }

--- a/test/tools/sshd-entrypoint.sh
+++ b/test/tools/sshd-entrypoint.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    if [ -x /opt/homebrew/bin/bash ]; then
+        exec /opt/homebrew/bin/bash "$0" "$@"
+    fi
+
+    echo "FAIL: Bash 4 or newer is required for this test" >&2
+    exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+    if [ -f "${tmpdir}/sshd.pid" ]; then
+        kill "$(cat "${tmpdir}/sshd.pid")" >/dev/null 2>&1 || true
+    fi
+    rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+mkdir -p "${tmpdir}/bin" "${tmpdir}/etc-ssh" "${tmpdir}/home/root"
+
+cat > "${tmpdir}/bin/getent" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "\${1:-}" = "passwd" ] && [ "\${2:-}" = "root" ]; then
+    printf 'root:x:0:0:root:${tmpdir}/home/root:/bin/bash\n'
+    exit 0
+fi
+
+exit 2
+EOF
+
+cat > "${tmpdir}/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+
+cat > "${tmpdir}/bin/ssh-keygen" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "-A" ]; then
+    mkdir -p "${SSHD_CONFIG_DIR}"
+    for type in rsa ecdsa ed25519; do
+        printf 'private-%s\n' "${type}" > "${SSHD_CONFIG_DIR}/ssh_host_${type}_key"
+        printf 'public-%s\n' "${type}" > "${SSHD_CONFIG_DIR}/ssh_host_${type}_key.pub"
+    done
+    exit 0
+fi
+
+echo "unexpected ssh-keygen invocation: $*" >&2
+exit 1
+EOF
+
+cat > "${tmpdir}/bin/sshd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" > "${TEST_TMPDIR}/sshd-start.log"
+echo "$$" > "${TEST_TMPDIR}/sshd.pid"
+
+while true; do
+    sleep 60
+done
+EOF
+
+chmod +x "${tmpdir}/bin/getent" "${tmpdir}/bin/pgrep" "${tmpdir}/bin/ssh-keygen" "${tmpdir}/bin/sshd"
+
+PATH="${tmpdir}/bin:${PATH}" \
+TEST_TMPDIR="${tmpdir}" \
+SSHD_ENABLE=true \
+SSHD_CONFIG_DIR="${tmpdir}/etc-ssh" \
+SSHD_RUN_DIR="${tmpdir}/run-sshd" \
+SSHD_HOST_KEY_DIR="${tmpdir}/host-keys" \
+SSH_AUTHORIZED_KEYS="ssh-ed25519 test-key root@example" \
+    "${BASH}" "${repo_root}/src/tools/tailscale-entrypoint.sh" sleep 0.2
+
+for _ in {1..20}; do
+    [ -f "${tmpdir}/sshd-start.log" ] && break
+    sleep 0.1
+done
+
+test -f "${tmpdir}/sshd-start.log" || {
+    echo "FAIL: sshd was not started"
+    exit 1
+}
+
+grep -q -- '-D -e' "${tmpdir}/sshd-start.log" || {
+    echo "FAIL: sshd was not started in foreground logging mode"
+    cat "${tmpdir}/sshd-start.log"
+    exit 1
+}
+
+test -f "${tmpdir}/host-keys/ssh_host_ed25519_key" || {
+    echo "FAIL: persistent SSH host keys were not generated"
+    exit 1
+}
+
+test -L "${tmpdir}/etc-ssh/ssh_host_ed25519_key" || {
+    echo "FAIL: SSH host key was not linked into SSH config dir"
+    exit 1
+}
+
+grep -q 'ssh-ed25519 test-key root@example' "${tmpdir}/home/root/.ssh/authorized_keys" || {
+    echo "FAIL: SSH_AUTHORIZED_KEYS was not written to root authorized_keys"
+    exit 1
+}
+
+echo "PASS: sshd starts and configures persistent host keys"

--- a/test/tools/sshd-only.sh
+++ b/test/tools/sshd-only.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+echo "Testing sshd-only installation..."
+
+command -v sshd >/dev/null || test -x /usr/sbin/sshd || { echo "FAIL: sshd is not installed"; exit 1; }
+test -x /usr/local/bin/tailscale-entrypoint.sh || { echo "FAIL: tailscale entrypoint is not executable"; exit 1; }
+
+command -v tailscale >/dev/null && { echo "FAIL: tailscale should not be installed"; exit 1; }
+command -v tailscaled >/dev/null && { echo "FAIL: tailscaled should not be installed"; exit 1; }
+command -v lazygit >/dev/null && { echo "FAIL: lazygit should not be installed"; exit 1; }
+command -v gh >/dev/null && { echo "FAIL: gh should not be installed"; exit 1; }
+
+echo "All tests passed!"

--- a/test/tools/tailscale-entrypoint-auth-key-first.sh
+++ b/test/tools/tailscale-entrypoint-auth-key-first.sh
@@ -115,4 +115,11 @@ if ! grep -q -- '--auth-key=tskey-auth-test' "${tmpdir}/tailscale-up.log"; then
     exit 1
 fi
 
+if ! grep -q -- '--reset' "${tmpdir}/tailscale-up.log"; then
+    echo "FAIL: first tailscale up did not reset existing state when TS_AUTH_KEY was provided"
+    echo "Recorded invocations:"
+    cat "${tmpdir}/tailscale-up.log"
+    exit 1
+fi
+
 echo "PASS: tailscale entrypoint uses TS_AUTH_KEY before state-only login"

--- a/test/tools/tailscale-entrypoint-auth-key-first.sh
+++ b/test/tools/tailscale-entrypoint-auth-key-first.sh
@@ -105,6 +105,7 @@ TS_STATE_DIR="${tmpdir}/state" \
 TS_SOCKET="${tmpdir}/tailscaled.sock" \
 TS_AUTH_KEY="tskey-auth-test" \
 TS_ENABLE_SSH=false \
+SSHD_ENABLE=false \
 TS_TAG= \
     "${BASH}" "${repo_root}/src/tools/tailscale-entrypoint.sh" true
 

--- a/test/tools/test.sh
+++ b/test/tools/test.sh
@@ -18,6 +18,7 @@ check "codex is installed" codex --version
 check "tailscale is installed" tailscale version
 check "tailscaled is installed" tailscaled --version
 check "tailscale entrypoint is installed" test -x /usr/local/bin/tailscale-entrypoint.sh
+check "sshd is installed" sh -c 'command -v sshd >/dev/null || test -x /usr/sbin/sshd'
 
 # Report result
 reportResults


### PR DESCRIPTION
## Summary

- Add optional OpenSSH server installation and runtime startup to the `tools` feature.
- Persist SSH host keys in a named volume and support `SSH_AUTHORIZED_KEYS` / `SSH_AUTHORIZED_KEYS_FILE` at entrypoint startup.
- Bump the `tools` feature version to `1.4.0` and update generated feature docs/tests.

## Validation

- `bash test/tools/tailscale-entrypoint-auth-key-first.sh`
- `bash test/tools/sshd-entrypoint.sh`
- `TMPDIR="$PWD/.tmp" devcontainer features test -f tools --skip-autogenerated --skip-duplicated --filter sshd-only .`
