### PR TITLE
[codex] Add build tools option to tools feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Custom [Dev Container Features](https://containers.dev/features) published to Gi
 ## Available Features
 
 - [`devenv`](./src/devenv) - terminal-focused development environment with tmux, lazygit, Neovim, GitHub CLI, and AI coding CLIs.
-- [`tools`](./src/tools) - minimal terminal-focused tool bundle with lazygit, Neovim, GitHub CLI, AI coding CLIs, Tailscale access, and optional normal SSH access.
+- [`tools`](./src/tools) - minimal terminal-focused tool bundle with lazygit, Neovim, GitHub CLI, AI coding CLIs, C/C++ build tools, Tailscale access, and optional normal SSH access.
 - [`tig`](./src/tig) - installs [`tig`](https://jonas.github.io/tig/), the text-mode interface for Git.
 
 ## `devenv`
@@ -68,7 +68,7 @@ Disable individual tools or pin supported tool versions as needed:
 
 ## `tools`
 
-A minimal dev container feature that bundles terminal-based development tools: lazygit, neovim (with ripgrep, fd, fzf), gh, Claude Code, Codex, fdsx, rtk, pi, Tailscale access, and an optional OpenSSH server for normal SSH clients.
+A minimal dev container feature that bundles terminal-based development tools: lazygit, neovim (with ripgrep, fd, fzf), gh, Claude Code, Codex, fdsx, rtk, pi, C/C++ build tools, Tailscale access, and an optional OpenSSH server for normal SSH clients.
 
 ### Example Usage
 
@@ -104,7 +104,8 @@ Disable individual tools or pin supported tool versions as needed:
       "installRtk": true,
       "installPi": true,
       "installTailscale": true,
-      "installSshd": true
+      "installSshd": true,
+      "installBuildTools": true
     }
   }
 }
@@ -126,8 +127,9 @@ Disable individual tools or pin supported tool versions as needed:
 | `installPi` | Install pi coding agent | boolean | `true` |
 | `installTailscale` | Install Tailscale and configure the tools entrypoint for Tailscale SSH | boolean | `true` |
 | `installSshd` | Install and start OpenSSH server for normal SSH access | boolean | `true` |
+| `installBuildTools` | Install python3, make, and a C++ compiler when missing | boolean | `true` |
 
-The `tools` feature metadata sets `/usr/local/bin/tailscale-entrypoint.sh` as the entrypoint and adds `NET_ADMIN`, `NET_RAW`, and `MKNOD`. It persists Tailscale state in `/var/lib/tailscale` and SSH host keys in `/var/lib/ssh-host-keys`. For normal SSH access, provide a public key with `SSH_AUTHORIZED_KEYS` or `SSH_AUTHORIZED_KEYS_FILE`. For Dockerfile-only usage, set `INSTALLTAILSCALE=false` or `INSTALLSSHD=false` to skip either service installation.
+The `tools` feature metadata sets `/usr/local/bin/tailscale-entrypoint.sh` as the entrypoint and adds `NET_ADMIN`, `NET_RAW`, and `MKNOD`. It persists Tailscale state in `/var/lib/tailscale` and SSH host keys in `/var/lib/ssh-host-keys`. For normal SSH access, provide a public key with `SSH_AUTHORIZED_KEYS` or `SSH_AUTHORIZED_KEYS_FILE`. For Dockerfile-only usage, set `INSTALLTAILSCALE=false`, `INSTALLSSHD=false`, or `INSTALLBUILDTOOLS=false` to skip specific service or build-tool installation.
 
 ## `tig`
 

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -1,7 +1,7 @@
 
 # tools (tools)
 
-A minimal dev container feature that bundles terminal-based development tools, Tailscale access, and an optional OpenSSH server.
+A minimal dev container feature that bundles terminal-based development tools, C/C++ build tools, Tailscale access, and an optional OpenSSH server.
 
 ## Example Usage
 
@@ -27,6 +27,7 @@ A minimal dev container feature that bundles terminal-based development tools, T
 | installPi | Install pi coding agent | boolean | true |
 | installTailscale | Install Tailscale and configure the tools entrypoint for Tailscale SSH | boolean | true |
 | installSshd | Install and start OpenSSH server for normal SSH access | boolean | true |
+| installBuildTools | Install python3, make, and a C++ compiler when missing | boolean | true |
 
 
 

--- a/src/tools/devcontainer-feature.json
+++ b/src/tools/devcontainer-feature.json
@@ -1,8 +1,8 @@
 {
     "name": "tools",
     "id": "tools",
-    "version": "1.4.0",
-    "description": "A minimal dev container feature that bundles terminal-based development tools, Tailscale access, and an optional OpenSSH server.",
+    "version": "1.5.0",
+    "description": "A minimal dev container feature that bundles terminal-based development tools, C/C++ build tools, Tailscale access, and an optional OpenSSH server.",
     "entrypoint": "/usr/local/bin/tailscale-entrypoint.sh",
     "capAdd": [
         "NET_ADMIN",
@@ -87,6 +87,11 @@
         "installSshd": {
             "type": "boolean",
             "description": "Install and start OpenSSH server for normal SSH access",
+            "default": true
+        },
+        "installBuildTools": {
+            "type": "boolean",
+            "description": "Install python3, make, and a C++ compiler when missing",
             "default": true
         }
     }

--- a/src/tools/install.sh
+++ b/src/tools/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # tools feature install script
 # Installs lazygit, neovim (with supporting tools: ripgrep, fd, fzf), gh,
-# Claude Code, Codex, fdsx, rtk, pi, optional Tailscale access, and OpenSSH
+# Claude Code, Codex, fdsx, rtk, pi, build tools, optional Tailscale access, and OpenSSH
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -18,6 +18,7 @@ INSTALL_RTK="${INSTALLRTK:-true}"
 INSTALL_PI="${INSTALLPI:-true}"
 INSTALL_TAILSCALE="${INSTALLTAILSCALE:-true}"
 INSTALL_SSHD="${INSTALLSSHD:-true}"
+INSTALL_BUILD_TOOLS="${INSTALLBUILDTOOLS:-true}"
 LAZYGIT_VERSION="${LAZYGITVERSION:-latest}"
 NVIM_VERSION="${NVIMVERSION:-latest}"
 
@@ -118,6 +119,40 @@ install_dependencies() {
         apk add --no-cache curl ca-certificates tar gzip xz
     elif command -v dnf &>/dev/null; then
         dnf install -y curl ca-certificates tar gzip xz
+    fi
+}
+
+has_build_tools() {
+    command -v python3 &>/dev/null \
+        && command -v make &>/dev/null \
+        && { command -v g++ &>/dev/null || command -v clang++ &>/dev/null; }
+}
+
+install_build_tools() {
+    if [ "$INSTALL_BUILD_TOOLS" != "true" ]; then
+        echo "Skipping C/C++ build tools installation (disabled)"
+        return 0
+    fi
+
+    if has_build_tools; then
+        echo "C/C++ build tools are already installed, skipping"
+        return 0
+    fi
+
+    echo "Installing C/C++ build tools..."
+    if command -v apt-get &>/dev/null; then
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y --no-install-recommends build-essential python3
+        apt-get clean
+        rm -rf /var/lib/apt/lists/*
+    elif command -v apk &>/dev/null; then
+        apk add --no-cache build-base python3
+    elif command -v dnf &>/dev/null; then
+        dnf install -y make gcc-c++ python3
+    else
+        echo "WARNING: Could not find a supported package manager for C/C++ build tools" >&2
+        return 0
     fi
 }
 
@@ -781,6 +816,7 @@ main() {
     echo "  INSTALL_PI=$INSTALL_PI"
     echo "  INSTALL_TAILSCALE=$INSTALL_TAILSCALE"
     echo "  INSTALL_SSHD=$INSTALL_SSHD"
+    echo "  INSTALL_BUILD_TOOLS=$INSTALL_BUILD_TOOLS"
     echo "  LAZYGIT_VERSION=$LAZYGIT_VERSION"
     echo "  NVIM_VERSION=$NVIM_VERSION"
 
@@ -792,6 +828,7 @@ main() {
     mkdir -p /etc/profile.d
 
     install_dependencies
+    install_build_tools
     install_tailscale
     install_sshd
     install_lazygit

--- a/test/tools/build-tools-install.sh
+++ b/test/tools/build-tools-install.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    if [ -x /opt/homebrew/bin/bash ]; then
+        exec /opt/homebrew/bin/bash "$0" "$@"
+    fi
+
+    echo "FAIL: Bash 4 or newer is required for this test" >&2
+    exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+mkdir -p "${tmpdir}/bin"
+
+cat > "${tmpdir}/bin/apt-get" <<'EOF'
+#!/bin/sh
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${TEST_TMPDIR}/apt-get.log"
+exit 0
+EOF
+
+cat > "${tmpdir}/bin/uname" <<'EOF'
+#!/bin/sh
+printf 'x86_64\n'
+EOF
+
+cat > "${tmpdir}/bin/dirname" <<'EOF'
+#!/bin/sh
+value="${1%/*}"
+if [ "${value}" = "${1}" ]; then
+    printf '.\n'
+else
+    printf '%s\n' "${value}"
+fi
+EOF
+
+cat > "${tmpdir}/bin/pwd" <<'EOF'
+#!/bin/sh
+printf '%s\n' "${PWD}"
+EOF
+
+cat > "${tmpdir}/bin/mkdir" <<'EOF'
+#!/bin/sh
+set -euo pipefail
+
+for arg in "$@"; do
+    if [ "${arg}" = "/etc/profile.d" ]; then
+        exit 0
+    fi
+done
+
+/bin/mkdir "$@"
+EOF
+
+cat > "${tmpdir}/bin/install" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+cat > "${tmpdir}/bin/rm" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+chmod +x "${tmpdir}/bin/apt-get" "${tmpdir}/bin/uname" "${tmpdir}/bin/dirname" "${tmpdir}/bin/pwd" "${tmpdir}/bin/mkdir" "${tmpdir}/bin/install" "${tmpdir}/bin/rm"
+
+PATH="${tmpdir}/bin" \
+TEST_TMPDIR="${tmpdir}" \
+INSTALLLAZYGIT=false \
+INSTALLNVIM=false \
+INSTALLCLAUDECODE=false \
+INSTALLCODEX=false \
+INSTALLGH=false \
+INSTALLFDSX=false \
+INSTALLRTK=false \
+INSTALLPI=false \
+INSTALLTAILSCALE=false \
+INSTALLSSHD=false \
+    "${BASH}" "${repo_root}/src/tools/install.sh"
+
+if ! grep -q -- 'install .*build-essential' "${tmpdir}/apt-get.log"; then
+    echo "FAIL: build-essential was not requested when build tools were missing"
+    cat "${tmpdir}/apt-get.log"
+    exit 1
+fi
+
+if ! grep -q -- 'install .*python3' "${tmpdir}/apt-get.log"; then
+    echo "FAIL: python3 was not requested when build tools were missing"
+    cat "${tmpdir}/apt-get.log"
+    exit 1
+fi
+
+echo "PASS: missing build tools are installed"

--- a/test/tools/build-tools-only.sh
+++ b/test/tools/build-tools-only.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+echo "Testing build-tools-only installation..."
+
+command -v python3 >/dev/null || { echo "FAIL: python3 is not installed"; exit 1; }
+command -v make >/dev/null || { echo "FAIL: make is not installed"; exit 1; }
+command -v g++ >/dev/null || command -v clang++ >/dev/null || { echo "FAIL: C++ compiler is not installed"; exit 1; }
+
+command -v tailscale >/dev/null && { echo "FAIL: tailscale should not be installed"; exit 1; }
+command -v tailscaled >/dev/null && { echo "FAIL: tailscaled should not be installed"; exit 1; }
+command -v sshd >/dev/null && { echo "FAIL: sshd should not be installed"; exit 1; }
+command -v lazygit >/dev/null && { echo "FAIL: lazygit should not be installed"; exit 1; }
+command -v gh >/dev/null && { echo "FAIL: gh should not be installed"; exit 1; }
+
+echo "All tests passed!"

--- a/test/tools/scenarios.json
+++ b/test/tools/scenarios.json
@@ -12,7 +12,8 @@
                 "installRtk": false,
                 "installPi": false,
                 "installTailscale": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -28,7 +29,8 @@
                 "installRtk": false,
                 "installPi": false,
                 "installTailscale": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -44,7 +46,8 @@
                 "installRtk": false,
                 "installPi": false,
                 "installTailscale": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -60,7 +63,8 @@
                 "installRtk": false,
                 "installPi": false,
                 "installTailscale": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -76,7 +80,8 @@
                 "installRtk": false,
                 "installPi": false,
                 "installTailscale": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -92,7 +97,8 @@
                 "installRtk": false,
                 "installPi": false,
                 "installTailscale": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -108,7 +114,8 @@
                 "installRtk": false,
                 "installPi": false,
                 "installTailscale": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -124,7 +131,8 @@
                 "installRtk": false,
                 "installPi": false,
                 "installTailscale": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -140,7 +148,8 @@
                 "installFdsx": false,
                 "installPi": false,
                 "installTailscale": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -156,7 +165,8 @@
                 "installFdsx": false,
                 "installRtk": false,
                 "installTailscale": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -172,7 +182,8 @@
                 "installFdsx": false,
                 "installRtk": false,
                 "installPi": false,
-                "installSshd": false
+                "installSshd": false,
+                "installBuildTools": false
             }
         }
     },
@@ -188,7 +199,25 @@
                 "installFdsx": false,
                 "installRtk": false,
                 "installPi": false,
-                "installTailscale": false
+                "installTailscale": false,
+                "installBuildTools": false
+            }
+        }
+    },
+    "build-tools-only": {
+        "image": "debian:trixie-slim",
+        "features": {
+            "tools": {
+                "installLazygit": false,
+                "installNvim": false,
+                "installClaudeCode": false,
+                "installCodex": false,
+                "installGh": false,
+                "installFdsx": false,
+                "installRtk": false,
+                "installPi": false,
+                "installTailscale": false,
+                "installSshd": false
             }
         }
     }

--- a/test/tools/test.sh
+++ b/test/tools/test.sh
@@ -19,6 +19,9 @@ check "tailscale is installed" tailscale version
 check "tailscaled is installed" tailscaled --version
 check "tailscale entrypoint is installed" test -x /usr/local/bin/tailscale-entrypoint.sh
 check "sshd is installed" sh -c 'command -v sshd >/dev/null || test -x /usr/sbin/sshd'
+check "python3 is installed" python3 --version
+check "make is installed" make --version
+check "C++ compiler is installed" sh -c 'command -v g++ >/dev/null || command -v clang++ >/dev/null'
 
 # Report result
 reportResults


### PR DESCRIPTION
## Summary

- Add an `installBuildTools` option to the `tools` feature, enabled by default.
- Install `python3`, `make`, and a C++ compiler when build tools are missing across supported package managers.
- Bump the `tools` feature version to `1.5.0` and update generated docs and scenarios.

## Validation

- `bash test/tools/build-tools-install.sh`
- `jq empty src/tools/devcontainer-feature.json test/tools/scenarios.json`
- `TMPDIR="$PWD/.tmp" devcontainer features test -f tools --skip-autogenerated --skip-duplicated --filter build-tools-only .`
